### PR TITLE
Add i18n support and fix testing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Marvel App
 
 ## Introduction
-This project is a React + TypeScript web application that fetches and displays information about Marvel characters. It features a listing page, detailed character view, search functionality, and a favorites system.
+This project is a React + TypeScript web application that fetches and displays information about Marvel characters. It features a listing page, detailed character view, search functionality, a favorites system, and multilingual support.
 
 ## Features
 - **Character Listing Page**: Displays the first 50 characters or the search results.
@@ -13,6 +13,7 @@ This project is a React + TypeScript web application that fetches and displays i
 - **State Management**: Uses Zustand for efficient state handling.
 - **Data Fetching & Caching**: Utilizes React Query for optimized API calls.
 - **Testing**: Comprehensive unit and integration tests using Vitest and React Testing Library.
+- **Internationalization (i18n)**: Supports multiple languages with automatic browser language detection.
 
 ## Technologies Used
 - **React** (v18+)
@@ -20,6 +21,7 @@ This project is a React + TypeScript web application that fetches and displays i
 - **Zustand** (state management)
 - **React Query** (API caching and data fetching)
 - **React Router** (navigation)
+- **React-i18next** (internationalization)
 - **CSS** (custom styles, no UI component libraries)
 - **Vitest & React Testing Library** (testing framework)
 - **Vite** (modern build tool for performance optimization)
@@ -70,6 +72,37 @@ yarn build && yarn preview
 ```
 This serves the built app locally to test the production mode.
 
+## Internationalization (i18n)
+The app now supports **automatic language detection** and **manual language switching** using `react-i18next`. It defaults to English, but if the browser is set to Spanish, it switches automatically.
+
+### **Adding a New Language**
+1. Add a new JSON file in the `src/locales/` folder (e.g., `fr.json` for French).
+2. Update `i18n.ts` to include the new language resource.
+3. Restart the app to apply changes.
+
+### **Manual Language Switching**
+To change the language manually:
+```tsx
+import { useTranslation } from "react-i18next";
+const { i18n } = useTranslation();
+i18n.changeLanguage("es"); // Switch to Spanish
+```
+
+### **Testing i18n in Vitest**
+If tests fail due to missing translations, mock `react-i18next`:
+```tsx
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      key === "searchBar.results" && options?.count !== undefined
+        ? f"{options.count} results"
+        : key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
+```
+This ensures tests run without real translation dependencies.
+
 ## Project Structure
 ```
 marvel-app/
@@ -81,6 +114,8 @@ marvel-app/
 │   ├── store/              # Zustand state management
 │   ├── styles/             # Global and modular styles
 │   ├── types/              # TypeScript type definitions
+│   ├── locales/            # i18n JSON translation files
+│   ├── i18n.ts             # i18n setup and initialization
 │   ├── tests/              # Unit & integration tests
 │   ├── App.tsx             # Main application component
 │   ├── main.tsx            # ReactDOM render entry point

--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
   "dependencies": {
     "@tanstack/react-query": "^5.67.1",
     "axios": "^1.8.1",
+    "i18next": "^24.2.2",
+    "i18next-browser-languagedetector": "^8.0.4",
     "md5": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-i18next": "^15.4.1",
     "react-router-dom": "^7.2.0",
     "zustand": "^5.0.3"
   },
@@ -31,6 +34,7 @@
     "@types/md5": "^2.3.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/react-i18next": "^8.1.0",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.21.0",
     "eslint-config-prettier": "^10.0.2",

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { SearchBarProps } from "./types";
 import "../styles/SearchBar.css";
 
 function SearchBar({ onSearch, resultsCount }: SearchBarProps) {
+  const { t } = useTranslation();
   const [search, setSearch] = useState("");
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,12 +33,14 @@ function SearchBar({ onSearch, resultsCount }: SearchBarProps) {
         <input
           className="search-bar"
           type="text"
-          placeholder="SEARCH A CHARACTER..."
+          placeholder={t("searchBar.placeholder")}
           value={search}
           onChange={handleChange}
         />
       </div>
-      <p className="search-results">{resultsCount} RESULTS</p>
+      <p className="search-results">
+        {t("searchBar.results", { count: resultsCount })}
+      </p>
     </div>
   );
 }

--- a/src/components/__tests__/SearchBar.test.tsx
+++ b/src/components/__tests__/SearchBar.test.tsx
@@ -3,49 +3,61 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import SearchBar from "../SearchBar";
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      key === "searchBar.results" && options?.count !== undefined
+        ? `${options.count} results`
+        : key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
+
 describe("SearchBar Component", () => {
   it("renders correctly", () => {
     render(<SearchBar onSearch={() => {}} resultsCount={0} />);
-    
-    expect(screen.getByPlaceholderText("SEARCH A CHARACTER...")).toBeInTheDocument();
-    expect(screen.getByText("0 RESULTS")).toBeInTheDocument();
+
+    expect(
+      screen.getByPlaceholderText("searchBar.placeholder")
+    ).toBeInTheDocument();
+    expect(screen.getByText("0 results")).toBeInTheDocument();
   });
 
   it("updates input value when user types", () => {
     render(<SearchBar onSearch={() => {}} resultsCount={0} />);
-    
-    const input = screen.getByPlaceholderText("SEARCH A CHARACTER...") as HTMLInputElement;
-    
+
+    const input = screen.getByPlaceholderText(
+      "searchBar.placeholder"
+    ) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "Spider-Man" } });
+
     expect(input.value).toBe("Spider-Man");
   });
 
   it("calls onSearch with the correct value", () => {
     const mockOnSearch = vi.fn();
     render(<SearchBar onSearch={mockOnSearch} resultsCount={0} />);
-    
-    const input = screen.getByPlaceholderText("SEARCH A CHARACTER...");
 
+    const input = screen.getByPlaceholderText("searchBar.placeholder");
     fireEvent.change(input, { target: { value: "Hulk" } });
+
     expect(mockOnSearch).toHaveBeenCalledWith("Hulk");
   });
 
   it("shows the correct number of results", () => {
     render(<SearchBar onSearch={() => {}} resultsCount={5} />);
-    
-    expect(screen.getByText("5 RESULTS")).toBeInTheDocument();
+
+    expect(screen.getByText("5 results")).toBeInTheDocument();
   });
 
   it("calls onSearch with empty string when input is cleared", () => {
     const mockOnSearch = vi.fn();
     render(<SearchBar onSearch={mockOnSearch} resultsCount={0} />);
-  
-    const input = screen.getByPlaceholderText("SEARCH A CHARACTER...");
-  
-    fireEvent.change(input, { target: { value: "Thor" } }); 
-    fireEvent.change(input, { target: { value: "" } }); 
-  
-    expect(mockOnSearch).toHaveBeenCalledWith(""); 
+
+    const input = screen.getByPlaceholderText("searchBar.placeholder");
+    fireEvent.change(input, { target: { value: "Thor" } });
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(mockOnSearch).toHaveBeenCalledWith("");
   });
-  
 });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,30 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import enTranslation from "./locales/en.json";
+import esTranslation from "./locales/es.json";
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: enTranslation },
+      es: { translation: esTranslation },
+    },
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ["navigator", "localStorage", "sessionStorage", "cookie"],
+      caches: ["localStorage", "cookie"],
+    },
+  });
+
+const userLanguage = i18n.language || navigator.language || "en";
+if (!userLanguage.startsWith("es")) {
+  i18n.changeLanguage("en");
+} else {
+  i18n.changeLanguage("es");
+}
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,21 @@
+{
+    "home": {
+      "noResults": "No results found."
+    },
+    "favorites": {
+      "title": "Favorites",
+      "emptyMessage": "You don’t have any favorite characters yet."
+    },
+    "character": {
+      "noCharacterFound": "No character found",
+      "tryLater": "Try later.",
+      "descriptionComingSoon": "Description coming soon...",
+      "comics": "COMICS",
+      "noComics": "No comics available."
+    },
+    "searchBar": {
+      "placeholder": "Search a character...",
+      "results": "{{count}} results"
+    }
+  }
+  

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,21 @@
+{
+    "home": {
+      "noResults": "No results found."
+    },
+    "favorites": {
+      "title": "Favorites",
+      "emptyMessage": "You don’t have any favorite characters yet."
+    },
+    "character": {
+      "noCharacterFound": "No character found",
+      "tryLater": "Try later.",
+      "descriptionComingSoon": "Description coming soon...",
+      "comics": "COMICS",
+      "noComics": "No comics available."
+    },
+    "searchBar": {
+      "placeholder": "Busca un personaje...",
+      "results": "{{count}} resultados"
+    }
+  }
+  

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,12 @@
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
+import "./i18n.ts";
 const queryClient = new QueryClient();
 
-
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <QueryClientProvider client={queryClient}>
     <App />
-    </QueryClientProvider>
-)
+  </QueryClientProvider>
+);

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -7,8 +7,10 @@ import noResultsImage from "../assets/no-results.jpg";
 import "../styles/Character.css";
 import { useCharacterComics, useCharacter } from "../services/marvelService";
 import { SkeletonCharacter } from "../components/SkeletonCharacter";
+import { useTranslation } from "react-i18next";
 
 function Character() {
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const { favorites, addFavorite, removeFavorite } = useMarvelStore();
 
@@ -84,8 +86,9 @@ function Character() {
             <div className="character-description">
               <p>
                 {noCharacter
-                  ? "Try later."
-                  : character.description || "Description coming soon..."}
+                  ? t("character.tryLater")
+                  : character.description ||
+                    t("character.descriptionComingSoon")}
               </p>
             </div>
           </div>
@@ -94,7 +97,7 @@ function Character() {
 
       {!noCharacter && (
         <section className="comics-section">
-          {comics && comics.length > 0 && <h2>COMICS</h2>}
+          {comics && comics.length > 0 && <h2>{t("character.comics")}</h2>}
           <div className="comics-list">
             {comics && comics.length > 0 ? (
               comics.map((comic) => (
@@ -116,7 +119,7 @@ function Character() {
                 </div>
               ))
             ) : (
-              <p>No comics available.</p>
+              <p>{t("character.noComics")}</p>
             )}
           </div>
         </section>

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import CharacterCard from "../components/CharacterCard";
 import { CharacterType } from "../types/global";
+import { useTranslation } from "react-i18next";
 
 function Favorites() {
+  const { t } = useTranslation();
   const [favorites, setFavorites] = useState<CharacterType[]>([]);
 
   useEffect(() => {
@@ -14,14 +16,20 @@ function Favorites() {
 
   return (
     <div className="favorites-container">
-      <h1>Favorites</h1>
+      <h1>{t("favorites.title")}</h1>
       <div className="character-grid">
         {favorites.length > 0 ? (
           favorites.map((char) => (
-            <CharacterCard key={char.id} character={char} loading={false} toggleFavorite={() => {}} favorites={favorites} />
+            <CharacterCard
+              key={char.id}
+              character={char}
+              loading={false}
+              toggleFavorite={() => {}}
+              favorites={favorites}
+            />
           ))
         ) : (
-          <p>You don’t have any favorite characters yet.</p>
+          <p>{t("favorites.emptyMessage")}</p>
         )}
       </div>
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,15 +1,17 @@
-import { useState } from "react";
-import { HomeActions } from "./types";
-import { useMarvelStore } from "../store/useMarvelStore";
-import CharacterCard from "../components/CharacterCard";
-import SearchBar from "../components/SearchBar";
-import Navbar from "../components/Navbar";
 import "../styles/Home.css";
-import noResultsImage from "../assets/no-results.jpg";
 import { CharacterType } from "../types/global";
+import { HomeActions } from "./types";
 import { useCharacters } from "../services/marvelService";
+import { useMarvelStore } from "../store/useMarvelStore";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import CharacterCard from "../components/CharacterCard";
+import Navbar from "../components/Navbar";
+import noResultsImage from "../assets/no-results.jpg";
+import SearchBar from "../components/SearchBar";
 
 function Home() {
+  const { t } = useTranslation();
   const { data: characters = [], isLoading, isError } = useCharacters();
   const [search, setSearch] = useState<string>("");
   const [showFavorites, setShowFavorites] = useState<boolean>(false);
@@ -65,10 +67,8 @@ function Home() {
           </div>
         ) : isError || displayedCharacters.length === 0 ? (
           <div className="no-results">
-            <img src={noResultsImage} alt="No results found" />
-            <p className="error-message">
-              No results found.
-            </p>
+            <img src={noResultsImage} alt={t("home.noResults")} />
+            <p className="error-message">{t("home.noResults")}</p>
           </div>
         ) : (
           <div className="character-grid">

--- a/src/pages/__tests__/Favorites.test.tsx
+++ b/src/pages/__tests__/Favorites.test.tsx
@@ -5,6 +5,13 @@ import Favorites from "../Favorites";
 import { BrowserRouter } from "react-router-dom";
 import { JSX } from "react";
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
+
 const renderWithRouter = (ui: JSX.Element) => {
   return render(<BrowserRouter>{ui}</BrowserRouter>);
 };
@@ -24,14 +31,22 @@ describe("Favorites Component", () => {
   it("displays message when no favorites are saved", () => {
     renderWithRouter(<Favorites />);
 
-    expect(screen.getByText("Favorites")).toBeInTheDocument();
-    expect(screen.getByText("You don’t have any favorite characters yet.")).toBeInTheDocument();
+    expect(screen.getByText("favorites.title")).toBeInTheDocument();
+    expect(screen.getByText("favorites.emptyMessage")).toBeInTheDocument();
   });
 
   it("loads favorites from localStorage and displays them", () => {
     const mockFavorites = [
-      { id: 1, name: "Iron Man", thumbnail: { path: "path_to_image", extension: "jpg" } },
-      { id: 2, name: "Spider-Man", thumbnail: { path: "path_to_image", extension: "jpg" } },
+      {
+        id: 1,
+        name: "Iron Man",
+        thumbnail: { path: "path_to_image", extension: "jpg" },
+      },
+      {
+        id: 2,
+        name: "Spider-Man",
+        thumbnail: { path: "path_to_image", extension: "jpg" },
+      },
     ];
 
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
@@ -40,7 +55,7 @@ describe("Favorites Component", () => {
 
     renderWithRouter(<Favorites />);
 
-    expect(screen.getByText("Favorites")).toBeInTheDocument();
+    expect(screen.getByText("favorites.title")).toBeInTheDocument();
     expect(screen.getByText("Iron Man")).toBeInTheDocument();
     expect(screen.getByText("Spider-Man")).toBeInTheDocument();
   });

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -20,6 +20,13 @@ vi.mock("../../store/useMarvelStore", () => ({
   })),
 }));
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
+
 const createTestQueryClient = () =>
   new QueryClient({
     defaultOptions: {
@@ -142,7 +149,7 @@ describe("Home Component", () => {
     renderWithProviders(<Home />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No results found./i)).toBeInTheDocument();
+      expect(screen.getByText("home.noResults")).toBeInTheDocument();
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,7 +149,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/runtime@^7.12.5":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.25.0":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.9.tgz#aa4c6facc65b9cb3f87d75125ffd47781b475433"
   integrity sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==
@@ -689,6 +689,13 @@
   version "19.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.0.4.tgz#bedba97f9346bd4c0fe5d39e689713804ec9ac89"
   integrity sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==
+
+"@types/react-i18next@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-i18next/-/react-i18next-8.1.0.tgz#5faacbfe7dc0f24729c1df6914610bfe861a50de"
+  integrity sha512-d4xhcjX5b3roNMObRNMfb1HinHQlQLPo8xlDj60dnHeeAw2bBymR2cy/l1giJpHzo/ZFgSvgVUvIWr4kCrenCg==
+  dependencies:
+    react-i18next "*"
 
 "@types/react@^19.0.10":
   version "19.0.10"
@@ -1878,6 +1885,13 @@ html-encoding-sniffer@^4.0.0:
   dependencies:
     whatwg-encoding "^3.1.1"
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 http-proxy-agent@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
@@ -1893,6 +1907,20 @@ https-proxy-agent@^7.0.6:
   dependencies:
     agent-base "^7.1.2"
     debug "4"
+
+i18next-browser-languagedetector@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.4.tgz#9b16f6440b6aad3521f2ab1a2ffbb7d917397df2"
+  integrity sha512-f3frU3pIxD50/Tz20zx9TD9HobKYg47fmAETb117GKGPrhwcSSPJDoCposXlVycVebQ9GQohC3Efbpq7/nnJ5w==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
+i18next@^24.2.2:
+  version "24.2.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-24.2.2.tgz#3ba3d213302068d569142737f03f30929de696de"
+  integrity sha512-NE6i86lBCKRYZa5TaUDkU5S4HFgLIEJRLr3Whf2psgaxBleQ2LC1YW1Vc+SCgkAW7VEzndT6al6+CzegSUHcTQ==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
 
 iconv-lite@0.6.3:
   version "0.6.3"
@@ -2571,6 +2599,14 @@ react-dom@^19.0.0:
   dependencies:
     scheduler "^0.25.0"
 
+react-i18next@*, react-i18next@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-15.4.1.tgz#33f3e89c2f6c68e2bfcbf9aa59986ad42fe78758"
+  integrity sha512-ahGab+IaSgZmNPYXdV1n+OYky95TGpFwnKRflX/16dY04DsYYKHtVLjeny7sBSCREEcoMbAgSkFiGLF5g5Oofw==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    html-parse-stringify "^3.0.1"
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -3163,6 +3199,11 @@ vitest@^3.0.7:
     vite "^5.0.0 || ^6.0.0"
     vite-node "3.0.7"
     why-is-node-running "^2.3.0"
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
### Summary
- Added i18n support with `react-i18next`
- Implemented automatic language detection (Spanish & English)
- Updated tests to mock `react-i18next` and handle dynamic translations
- Improved test compatibility for SearchBar, Favorites, and Home components

### How to Test
1. Run `yarn dev` and verify language switching.
2. Run `yarn test` to ensure tests pass.